### PR TITLE
Prevent line breaks when printing tokens next to the probability matrix

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -154,7 +154,7 @@ if($sentence > $count) $sentence = $count;
 <div class="row">
 	<div id="svg"></div>
 	<div id="other"></div>
-    <div id="matrix"></div>
+    <div id="matrix" style="white-space: nowrap;"></div>
 </div>
 <div class="row<?php echo ($compare?" bottomRow":""); ?>" style="margin-left:5px;" id="bottomRow">
 </div>


### PR DESCRIPTION
For a word like `cherry-pick` the Visualization in the Web Browser and when exporting a PNG is imperfect, as the line breaks at the `-` token:
![linebreak](https://user-images.githubusercontent.com/5872749/51485999-d0b46680-1d9f-11e9-99a2-9cf536e95e28.png)
With this PR the line break does not happen anymore:
![nolinebreak](https://user-images.githubusercontent.com/5872749/51486030-e2960980-1d9f-11e9-9173-b553153a5e57.png)
For this example I think not breaking the line is preferable. Even so the last character of `cherry-pick` is not shown entirely after exporting the png, the mapping of tokens to columns is intuitively clear.